### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,8 @@
 PingSerial	KEYWORD1
 begin	KEYWORD2
-data_available   KEYWORD2
-get_distance   KEYWORD2
-get_temperature   KEYWORD2
-request_distance   KEYWORD2
-request_temperature   KEYWORD2
-display_debugging   KEYWORD2
+data_available	KEYWORD2
+get_distance	KEYWORD2
+get_temperature	KEYWORD2
+request_distance	KEYWORD2
+request_temperature	KEYWORD2
+display_debugging	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords