### PR TITLE
Make it possible to build for ESP8266 core 2.6.3

### DIFF
--- a/PingSerial.cpp
+++ b/PingSerial.cpp
@@ -188,11 +188,7 @@ PingSerial::data_available (void)
 
     if (OPERATION_PENDING && (millis() > _op_started + _op_timeout_ms)) {
         // Operation timed out - discard all pending serial data, and kick it off again
-
-        // Increment counter but make sure if we've looped we set it to 1
-        // (we've lost info, but better than thinking we've had no timeouts)
         _timeout_count++;
-        _timeout_count = max(_timeout_count, 1); 
 
         if (_hw_serial) {
             available = _hw_serial->available();

--- a/PingSerial.h
+++ b/PingSerial.h
@@ -106,7 +106,7 @@ class PingSerial {
       unsigned long _op_started = 0;
       unsigned long _max_op_duration_ms = 0;
       uint16_t      _op_timeout_ms = 0;
-      uint16_t      _timeout_count = 0;
+      uint32_t      _timeout_count = 0;
 
       // Stored values
       uint16_t _distance = 0; // Distance is always positive, max (255 * 256 + 255) = 65535

--- a/PingSerial.h
+++ b/PingSerial.h
@@ -104,7 +104,7 @@ class PingSerial {
 
       // Internal state, mostly for debugging purposes (see display_debugging())
       unsigned long _op_started = 0;
-      uint16_t      _max_op_duration_ms = 0;
+      unsigned long _max_op_duration_ms = 0;
       uint16_t      _op_timeout_ms = 0;
       uint16_t      _timeout_count = 0;
 


### PR DESCRIPTION
These two commits made it possible to build and use the PingSerial library on my ESP8266 device building with PlatformIO and ESP8266 core for Arduino version 2.6.3.