### PR TITLE
Fix compile error when max() is a template function

### DIFF
--- a/PingSerial.cpp
+++ b/PingSerial.cpp
@@ -192,7 +192,7 @@ PingSerial::data_available (void)
         // Increment counter but make sure if we've looped we set it to 1
         // (we've lost info, but better than thinking we've had no timeouts)
         _timeout_count++;
-        _timeout_count = max(_timeout_count, 1); 
+        _timeout_count = max(_timeout_count, (uint16_t)1);
 
         if (_hw_serial) {
             available = _hw_serial->available();

--- a/PingSerial.h
+++ b/PingSerial.h
@@ -104,7 +104,7 @@ class PingSerial {
 
       // Internal state, mostly for debugging purposes (see display_debugging())
       unsigned long _op_started = 0;
-      uint16_t      _max_op_duration_ms = 0;
+      unsigned long _max_op_duration_ms = 0;
       uint16_t      _op_timeout_ms = 0;
       uint16_t      _timeout_count = 0;
 


### PR DESCRIPTION
When max() is a template function instead of a macro the two arguments
to it must be of same type.

The problem was raised in issue
https://github.com/stoduk/PingSerial/issues/6
"Cant compile for nodemcu/ESP8266"
and I had the same problem when trying to use the library.

This change is the same that Anthony Toole proposed as a fix for this
issue. I have verified that with this change the library works also
with ESP8266 core 2.6.3.